### PR TITLE
[Feat] Add ANNOY Model

### DIFF
--- a/top_k_recommendation/model/annoy.py
+++ b/top_k_recommendation/model/annoy.py
@@ -1,0 +1,26 @@
+from tqdm import tqdm
+from annoy import AnnoyIndex
+
+def build_annoy(df_biz,args):
+    """
+    build trees
+    """
+    length_of_vector = args.d_embed
+    num_data = df_biz.shape[0]
+    annoy_index = AnnoyIndex(length_of_vector, 'angular')  
+    for idx in tqdm(range(num_data)):
+        vector = df_biz.iloc[idx]['embedding']
+        annoy_index.add_item(idx, vector)
+    annoy_index.build(args.n_trees) 
+    annoy_index.save('patent_ann.annoy')
+
+class Annoy:
+    def __init__(self, args, annoy_index):
+        self.n_trees = args.n_trees
+        self.n = args.n
+        self.d_embed = args.d_embed
+        self.annoy_index = annoy_index
+        
+    def find_annoy(self,vector):
+        ann_idx, ann_score = self.annoy_index.get_nns_by_vector(vector, self.n, include_distances=True)
+        return ann_idx[::-1],ann_score[::-1]


### PR DESCRIPTION
## Overview
- 특허를 가지고 있는 기업의 Corpus가 너무나 크기 때문에 확장성 있는 추천을 하기 위해 도입함
- 모든 기업에 대해서 순위를 매기는 것보다 후보 생성 네트워크에서 추천할 기업의 수를 줄이고 랭킹 네트워크에서 순위를 매기는 것이 훨씬 빠름
## Change Log
- annoy.py 추가
## To Reviewer
ANNOY를 이용해 ANN을 빠르게 적용할 수 있도록 했습니다. 
## Issue Tags
- Closed | Fixed: #8 
